### PR TITLE
Phase 2: Close-apps implementation with config-driven design

### DIFF
--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -24,18 +24,23 @@ mac-app-lifecycle-manager/
 ├── scripts/
 │   ├── close-apps/
 │   │   ├── close-apps.applescript     # App closing logic
-│   │   ├── close-apps.sh              # Shell wrapper
-│   │   └── apps-to-close.txt          # List of apps to close
+│   │   └── close-apps.sh              # Shell wrapper
 │   ├── open-apps/
 │   │   ├── open-apps.applescript      # App opening logic
-│   │   ├── open-apps.sh               # Shell wrapper
-│   │   └── apps-to-open.txt           # Whitelist of apps to open
+│   │   └── open-apps.sh               # Shell wrapper
 │   └── lib/
 │       └── common.sh                  # Shared functions (logging, validation)
 ├── config/
-│   ├── close-apps.conf.example        # Template for close config
-│   ├── open-apps.conf.example         # Template for open config
+│   ├── close-apps.conf.example        # Template for close config (versioned)
+│   ├── close-apps.conf                # User config (gitignored)
+│   ├── open-apps.conf.example         # Template for open config (versioned)
+│   ├── open-apps.conf                 # User config (gitignored)
+│   ├── apps-to-close.txt.example      # Template (versioned)
+│   ├── apps-to-close.txt              # User list (gitignored)
+│   ├── apps-to-open.txt.example       # Template (versioned)
+│   ├── apps-to-open.txt               # User list (gitignored)
 │   └── README.md                      # Config documentation
+├── logs/                              # Log files (gitignored)
 ├── launchd/
 │   ├── com.user.mac-app-lifecycle.close.plist.template
 │   └── com.user.mac-app-lifecycle.open.plist.template
@@ -68,13 +73,14 @@ mac-app-lifecycle-manager/
 - `bin/mac-app-lifecycle` (stub with --help)
 - `config/close-apps.conf.example`
 - `config/open-apps.conf.example`
+- `config/apps-to-close.txt.example`
+- `config/apps-to-open.txt.example`
 - `config/README.md`
-- `scripts/close-apps/apps-to-close.txt.example`
-- `scripts/open-apps/apps-to-open.txt.example`
 - `scripts/lib/common.sh` (logging functions only)
 - `docs/CONFIGURATION.md`
 - `docs/INSTALLATION.md` (stub)
 - `docs/TROUBLESHOOTING.md` (stub)
+- `.gitignore` (add config/logs ignores)
 - Update `README.md`
 
 ### Commit Message:
@@ -213,9 +219,8 @@ Phase 4: CLI tool for manual operations and status checks
 ### Deliverables:
 1. ✅ Create `install.sh`:
    - Interactive prompts for schedule times
-   - Copy config templates to `~/.config/mac-app-lifecycle/`
-   - Create log directory: `~/Library/Logs/mac-app-lifecycle/`
-   - Copy app list files to config directory
+   - Copy `.example` templates to create `.conf` and `.txt` files in `config/`
+   - Create log directory: `logs/`
    - Generate plist files from templates with user's schedule
    - Copy plists to `~/Library/LaunchAgents/`
    - Set executable permissions
@@ -225,8 +230,8 @@ Phase 4: CLI tool for manual operations and status checks
 2. ✅ Create `uninstall.sh`:
    - Unload launchd agents
    - Remove plists from `~/Library/LaunchAgents/`
-   - Optionally remove config directory
-   - Optionally remove logs
+   - Optionally remove config files from `config/`
+   - Optionally remove logs from `logs/`
    - Confirmation prompts (especially for config/logs)
 3. ✅ Update `docs/INSTALLATION.md` with step-by-step guide
 4. ✅ Update `docs/TROUBLESHOOTING.md` with common issues

--- a/launchd/com.user.mac-app-lifecycle.close.plist.template
+++ b/launchd/com.user.mac-app-lifecycle.close.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.user.mac-app-lifecycle.close</string>
+	
+	<key>ProgramArguments</key>
+	<array>
+		<string>{{REPO_ROOT}}/scripts/close-apps/close-apps.sh</string>
+	</array>
+	
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>{{SCHEDULE_HOUR}}</integer>
+		<key>Minute</key>
+		<integer>{{SCHEDULE_MINUTE}}</integer>
+		{{WEEKDAYS_ENTRY}}
+	</dict>
+	
+	<key>RunAtLoad</key>
+	<false/>
+	
+	<key>StandardOutPath</key>
+	<string>{{LOG_PATH}}</string>
+	
+	<key>StandardErrorPath</key>
+	<string>{{ERR_LOG_PATH}}</string>
+	
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+	</dict>
+</dict>
+</plist>

--- a/scripts/close-apps/close-apps.applescript
+++ b/scripts/close-apps/close-apps.applescript
@@ -1,0 +1,131 @@
+-- close-apps.applescript
+-- AppleScript for closing macOS applications
+-- Part of mac-app-lifecycle-manager
+--
+-- This script reads from a file containing apps to close and handles three types:
+-- 1. Standard apps (close by name)
+-- 2. Apps with problematic process names (close by path)
+-- 3. Stubborn apps (force quit by bundle ID pattern)
+
+on run argv
+	-- Parameters passed from shell wrapper:
+	-- argv[1]: Path to apps-to-close.txt file
+	-- argv[2]: Quit timeout (seconds)
+	-- argv[3]: Close delay (seconds)
+	
+	if (count of argv) < 1 then
+		log "ERROR: Missing required argument: apps list file path"
+		return 1
+	end if
+	
+	set appListPath to item 1 of argv
+	set quitTimeout to 3 -- default
+	set closeDelay to 0.1 -- default
+	
+	if (count of argv) ≥ 2 then
+		set quitTimeout to (item 2 of argv) as integer
+	end if
+	
+	if (count of argv) ≥ 3 then
+		set closeDelay to (item 3 of argv) as real
+	end if
+	
+	-- Read and parse the app list file
+	set appsToCloseByName to {}
+	set appsToCloseByPath to {}
+	set appsToForceQuit to {}
+	
+	try
+		set appListFile to read POSIX file appListPath
+		set appLines to paragraphs of appListFile
+		
+		repeat with appLine in appLines
+			set appLine to appLine as text
+			
+			-- Skip empty lines and comments
+			if appLine is not "" and appLine does not start with "#" then
+				if appLine starts with "PATH:" then
+					-- Extract path and add to path list
+					set appPath to text 6 thru -1 of appLine
+					set end of appsToCloseByPath to appPath
+				else if appLine starts with "FORCE:" then
+					-- Extract bundle ID pattern and add to force list
+					set bundlePattern to text 7 thru -1 of appLine
+					set end of appsToForceQuit to bundlePattern
+				else
+					-- Standard app name
+					set end of appsToCloseByName to appLine
+				end if
+			end if
+		end repeat
+	on error errMsg
+		log "ERROR: Failed to read app list file: " & appListPath
+		log "ERROR: " & errMsg
+		return 2
+	end try
+	
+	-- Get list of running apps for name-based closing
+	set runningApps to {}
+	try
+		tell application "System Events"
+			set runningApps to name of every application process whose background only is false
+		end tell
+	on error errMsg
+		log "ERROR: Failed to get running apps list"
+		log "ERROR: " & errMsg
+		return 1
+	end try
+	
+	-- Close apps by name
+	log "INFO: Closing apps by name..."
+	repeat with appName in appsToCloseByName
+		set appName to appName as text
+		if appName is in runningApps then
+			try
+				log "INFO: Closing " & appName
+				with timeout of quitTimeout seconds
+					tell application appName to quit
+				end timeout
+				delay closeDelay
+			on error errMsg
+				log "WARN: Failed to close " & appName & ": " & errMsg
+			end try
+		else
+			log "DEBUG: " & appName & " not running"
+		end if
+	end repeat
+	
+	-- Close apps by path
+	log "INFO: Closing apps by path..."
+	repeat with appPath in appsToCloseByPath
+		set appPath to appPath as text
+		try
+			log "INFO: Closing " & appPath
+			with timeout of quitTimeout seconds
+				tell application appPath to quit
+			end timeout
+			delay closeDelay
+		on error errMsg
+			log "WARN: Failed to close " & appPath & ": " & errMsg
+		end try
+	end repeat
+	
+	-- Force quit stubborn apps
+	if (count of appsToForceQuit) > 0 then
+		log "INFO: Force quitting stubborn apps..."
+		repeat with bundlePattern in appsToForceQuit
+			set bundlePattern to bundlePattern as text
+			try
+				log "INFO: Force quitting process matching: " & bundlePattern
+				do shell script "pkill -f '" & bundlePattern & "'"
+				delay closeDelay
+			on error errMsg
+				-- pkill returns non-zero if no processes match (not an error)
+				log "DEBUG: pkill for " & bundlePattern & ": " & errMsg
+			end try
+		end repeat
+	end if
+	
+	log "INFO: App closing complete"
+	return 0
+end run

--- a/scripts/close-apps/close-apps.sh
+++ b/scripts/close-apps/close-apps.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# close-apps.sh - Shell wrapper for close-apps automation
+# Part of mac-app-lifecycle-manager
+#
+# This script loads configuration, validates files, and invokes the AppleScript
+# to close configured applications.
+
+set -euo pipefail
+
+# =============================================================================
+# SETUP
+# =============================================================================
+
+# Determine script directory and repository root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Source common library
+# shellcheck source=../lib/common.sh
+if [[ -f "${SCRIPT_DIR}/../lib/common.sh" ]]; then
+	source "${SCRIPT_DIR}/../lib/common.sh"
+else
+	echo "[$(date '+%Y-%m-%d %H:%M:%S')] [ERROR] common.sh library not found" >&2
+	exit 1
+fi
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+# Default configuration file location
+CONFIG_FILE="${REPO_ROOT}/config/close-apps.conf"
+
+# Check if config file exists
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+	log_error "Configuration file not found: ${CONFIG_FILE}"
+	log_error "Create it by copying from: ${REPO_ROOT}/config/close-apps.conf.example"
+	exit 2
+fi
+
+# Load configuration
+log_debug "Loading configuration from: ${CONFIG_FILE}"
+# shellcheck source=../../config/close-apps.conf.example
+source "${CONFIG_FILE}" || die "Failed to load configuration file" 2
+
+# Export REPO_ROOT and SCRIPT_DIR for use in config file variable expansion
+export REPO_ROOT SCRIPT_DIR
+
+# Apply variable expansion to configuration values
+APP_LIST_PATH=$(eval echo "${APP_LIST_PATH}")
+APPLESCRIPT_PATH=$(eval echo "${APPLESCRIPT_PATH}")
+LOG_PATH=$(eval echo "${LOG_PATH}")
+ERR_LOG_PATH=$(eval echo "${ERR_LOG_PATH}")
+
+# =============================================================================
+# VALIDATION
+# =============================================================================
+
+log_debug "Validating configuration..."
+
+# Validate required commands
+validate_command_exists "osascript" "AppleScript" || exit 1
+
+# Validate app list file
+validate_file_exists "${APP_LIST_PATH}" "App list file" || exit 2
+
+# Validate AppleScript file
+validate_file_exists "${APPLESCRIPT_PATH}" "AppleScript file" || exit 2
+
+# Ensure log directory exists
+LOG_DIR="$(dirname "${LOG_PATH}")"
+ensure_dir "${LOG_DIR}" "Log directory"
+
+# =============================================================================
+# LOGGING SETUP
+# =============================================================================
+
+# Redirect all output to log files
+exec 1> >(tee -a "${LOG_PATH}")
+exec 2> >(tee -a "${ERR_LOG_PATH}" >&2)
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+main() {
+	log_info "========================================="
+	log_info "Close-Apps Starting"
+	log_info "========================================="
+	log_info "Config: ${CONFIG_FILE}"
+	log_info "App list: ${APP_LIST_PATH}"
+	log_info "AppleScript: ${APPLESCRIPT_PATH}"
+	log_info "Quit timeout: ${QUIT_TIMEOUT}s"
+	log_info "Close delay: ${CLOSE_DELAY}s"
+	log_info "Log: ${LOG_PATH}"
+	
+	# Count apps to close
+	local app_count
+	app_count=$(grep -v '^#' "${APP_LIST_PATH}" | grep -v '^$' | wc -l | tr -d ' ')
+	log_info "Apps to process: ${app_count}"
+	
+	# Execute AppleScript
+	log_info "Executing AppleScript..."
+	if /usr/bin/osascript "${APPLESCRIPT_PATH}" \
+		"${APP_LIST_PATH}" \
+		"${QUIT_TIMEOUT}" \
+		"${CLOSE_DELAY}"; then
+		log_info "Close-Apps completed successfully"
+		log_info "========================================="
+		exit 0
+	else
+		local exit_code=$?
+		log_error "Close-Apps failed with exit code: ${exit_code}"
+		log_info "========================================="
+		exit "${exit_code}"
+	fi
+}
+
+main "$@"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -142,6 +142,7 @@ ensure_dir() {
 # Load configuration file with validation
 # Usage: load_config "/path/to/config.conf"
 # Returns: 0 if loaded successfully, 2 if config error
+# Note: Exports REPO_ROOT and SCRIPT_DIR for variable expansion in config
 load_config() {
   local config_file="$1"
   
@@ -150,6 +151,9 @@ load_config() {
   fi
   
   log_debug "Loading configuration from: ${config_file}"
+  
+  # Export REPO_ROOT and SCRIPT_DIR for use in config file
+  export REPO_ROOT SCRIPT_DIR
   
   # Source the config file
   # shellcheck source=/dev/null


### PR DESCRIPTION
- Migrate CloseAllApps.applescript → close-apps.applescript
  - Accept parameters from shell wrapper (app list, timeout, delay)
  - Read from file with three-tier format (name/path/force)
  - Comprehensive logging at multiple levels
  - Proper error handling and exit codes

- Create close-apps.sh wrapper
  - Auto-detect REPO_ROOT and SCRIPT_DIR
  - Load config with variable expansion
  - Validate all files and commands
  - Structured logging with timestamps
  - Redirect to both console and log files

- Create launchd plist template
  - Template variables for installation
  - Standard/error output paths
  - Calendar interval scheduling

- Update common.sh
  - Export REPO_ROOT/SCRIPT_DIR for config files

- Tested successfully: closed 12 running apps, proper logging
