### PR TITLE
Adds installation and uninstallation scripts for lifecycle manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for complete reference.
 
 ## Documentation
 
+- **[COMMANDS.md](docs/COMMANDS.md)** - Complete commands reference and cheatsheet
 - **[CONFIGURATION.md](docs/CONFIGURATION.md)** - Complete configuration reference
 - **[INSTALLATION.md](docs/INSTALLATION.md)** - Installation guide (stub, full version in Phase 5)
 - **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - Common issues (expanded during migration)

--- a/bin/mac-app-lifecycle
+++ b/bin/mac-app-lifecycle
@@ -170,6 +170,7 @@ COMMANDS:
   close               Close configured applications
   open                Open whitelisted applications
   status              Show launchd agent status
+  plist               Show launchd plist configuration
   logs                Display recent logs
   help                Show this help message
   version             Show version information
@@ -190,6 +191,9 @@ EXAMPLES:
   # Check launchd agent status
   mac-app-lifecycle status
 
+  # View plist configuration
+  mac-app-lifecycle plist close
+
   # View close-apps logs
   mac-app-lifecycle logs close
 
@@ -202,9 +206,10 @@ CONFIGURATION:
   Launch agents: ~/Library/LaunchAgents/
 
 DOCUMENTATION:
-  Installation:     docs/INSTALLATION.md
-  Configuration:    docs/CONFIGURATION.md
-  Troubleshooting:  docs/TROUBLESHOOTING.md
+  Commands Reference:     docs/COMMANDS.md
+  Installation:           docs/INSTALLATION.md
+  Configuration:          docs/CONFIGURATION.md
+  Troubleshooting:        docs/TROUBLESHOOTING.md
 
 For more information, visit:
   https://github.com/yourusername/mac-app-lifecycle-manager
@@ -517,6 +522,93 @@ handle_status() {
     echo "      This command only shows current status"
 }
 
+handle_plist() {
+    verbose "DEBUG" "Handling plist command with args: $*"
+
+    local subcommand="${1:-}"
+
+    case "$subcommand" in
+        close)
+            show_close_plist
+            ;;
+        open)
+            show_open_plist
+            ;;
+        "")
+            error "Please specify 'close' or 'open' plist"
+            echo "Usage: mac-app-lifecycle plist <close|open>" >&2
+            echo "" >&2
+            echo "Available subcommands:" >&2
+            echo "  close    Show close-apps plist configuration" >&2
+            echo "  open     Show open-apps plist configuration" >&2
+            echo "" >&2
+            echo "Examples:" >&2
+            echo "  mac-app-lifecycle plist close" >&2
+            echo "  mac-app-lifecycle plist open" >&2
+            exit 1
+            ;;
+        *)
+            error "Unknown plist subcommand '$subcommand'"
+            echo "Usage: mac-app-lifecycle plist <close|open>" >&2
+            echo "" >&2
+            echo "Available subcommands:" >&2
+            echo "  close    Show close-apps plist configuration" >&2
+            echo "  open     Show open-apps plist configuration" >&2
+            exit 1
+            ;;
+    esac
+}
+
+show_close_plist() {
+    verbose "DEBUG" "Showing close-apps plist"
+
+    local plist_file="$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist"
+
+    echo "Close Apps Plist Configuration"
+    echo "=============================="
+    echo "Plist file: $plist_file"
+    echo ""
+
+    if [[ -f "$plist_file" ]]; then
+        if [[ -r "$plist_file" ]]; then
+            echo "Contents:"
+            echo ""
+            cat "$plist_file"
+        else
+            error "Plist file is not readable: $plist_file"
+            echo "Check file permissions: ls -la $plist_file" >&2
+        fi
+    else
+        warning "Plist file does not exist: $plist_file"
+        echo "Run the installation script to create it: ./install.sh" >&2
+    fi
+}
+
+show_open_plist() {
+    verbose "DEBUG" "Showing open-apps plist"
+
+    local plist_file="$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist"
+
+    echo "Open Apps Plist Configuration"
+    echo "============================="
+    echo "Plist file: $plist_file"
+    echo ""
+
+    if [[ -f "$plist_file" ]]; then
+        if [[ -r "$plist_file" ]]; then
+            echo "Contents:"
+            echo ""
+            cat "$plist_file"
+        else
+            error "Plist file is not readable: $plist_file"
+            echo "Check file permissions: ls -la $plist_file" >&2
+        fi
+    else
+        warning "Plist file does not exist: $plist_file"
+        echo "Run the installation script to create it: ./install.sh" >&2
+    fi
+}
+
 handle_logs() {
     verbose "DEBUG" "Handling logs command with args: $*"
 
@@ -636,6 +728,9 @@ parse_command() {
         status)
             handle_status "$@"
             ;;
+        plist)
+            handle_plist "$@"
+            ;;
         logs)
             handle_logs "$@"
             ;;
@@ -652,6 +747,7 @@ parse_command() {
             echo "  close    Close applications listed in config" >&2
             echo "  open     Open applications from whitelist" >&2
             echo "  status   Show current status of launchd agents" >&2
+            echo "  plist    Show launchd plist configuration" >&2
             echo "  logs     Show application logs" >&2
             echo "  help     Show this help message" >&2
             echo "  version  Show version information" >&2

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,282 @@
+# Commands Reference
+
+This document provides a comprehensive reference for all commands available in the macOS App Lifecycle Manager.
+
+## Quick Start
+
+```bash
+# Install the system
+./install.sh
+
+# Check status
+./bin/mac-app-lifecycle status
+
+# Close apps manually
+./bin/mac-app-lifecycle close --now
+
+# View logs
+./bin/mac-app-lifecycle logs close
+```
+
+## CLI Tool Commands
+
+The main `mac-app-lifecycle` command provides user-friendly operations:
+
+### Core Operations
+```bash
+# Close configured applications
+./bin/mac-app-lifecycle close --now
+./bin/mac-app-lifecycle close --dry-run    # Preview what would happen
+
+# Open whitelisted applications
+./bin/mac-app-lifecycle open --now
+./bin/mac-app-lifecycle open --verbose      # Show detailed output
+```
+
+### Status & Monitoring
+```bash
+# Check launchd agent status
+./bin/mac-app-lifecycle status
+
+# View plist configurations
+./bin/mac-app-lifecycle plist close
+./bin/mac-app-lifecycle plist open
+
+# View logs
+./bin/mac-app-lifecycle logs close
+./bin/mac-app-lifecycle logs open
+```
+
+### Information
+```bash
+# Show help
+./bin/mac-app-lifecycle help
+./bin/mac-app-lifecycle --help
+
+# Show version
+./bin/mac-app-lifecycle version
+./bin/mac-app-lifecycle --version
+```
+
+## Installation & Setup
+
+### Automated Installation
+```bash
+# Install with interactive prompts
+./install.sh
+
+# Install with dry-run (preview)
+./install.sh --dry-run
+
+# Install with verbose output
+./install.sh --verbose
+```
+
+### Uninstallation
+```bash
+# Remove the system
+./uninstall.sh
+```
+
+## Development & Testing
+
+### npm Scripts
+```bash
+# Run all tests
+npm test
+npm run test:all
+
+# Test specific components
+npm run test:cli              # CLI command tests
+npm run test:cli-options      # CLI option parsing tests
+npm run test:cli-integration  # CLI integration tests
+npm run test:open-apps        # Open-apps script tests
+npm run test:close-apps       # Close-apps script tests
+npm run test:release-it       # Release tooling tests
+
+# Development operations
+npm run open-apps             # Run open-apps script directly
+npm run close-apps            # Run close-apps script directly
+
+# Release management
+npm run release               # Create new release
+npm run release:major         # Major version bump
+npm run release:minor         # Minor version bump
+npm run release:patch         # Patch version bump
+npm run release:set           # Set specific version
+```
+
+### Direct Script Execution
+```bash
+# Test scripts directly
+./scripts/close-apps/close-apps.sh
+./scripts/open-apps/open-apps.sh
+
+# With dry-run mode
+DRY_RUN=1 ./scripts/close-apps/close-apps.sh
+DRY_RUN=1 ./scripts/open-apps/open-apps.sh
+
+# With verbose logging
+LOG_LEVEL=DEBUG ./scripts/close-apps/close-apps.sh
+```
+
+## System Integration
+
+### launchd Management
+```bash
+# Check if agents are loaded
+launchctl list | grep mac-app-lifecycle
+
+# Check specific agent status
+launchctl list com.user.mac-app-lifecycle.close
+launchctl list com.user.mac-app-lifecycle.open
+
+# View detailed agent information (macOS 11+)
+launchctl print gui/$(id -u)/com.user.mac-app-lifecycle.close
+launchctl print gui/$(id -u)/com.user.mac-app-lifecycle.open
+
+# Manual load/unload (normally handled by install.sh/uninstall.sh)
+launchctl load ~/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist
+launchctl unload ~/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist
+```
+
+### File System Checks
+```bash
+# Check if plist files exist
+ls -la ~/Library/LaunchAgents/com.user.mac-app-lifecycle.*.plist
+
+# Check configuration files
+ls -la config/
+
+# Check log files
+ls -la logs/
+
+# Check script permissions
+ls -la bin/ scripts/**/*.sh
+```
+
+## Troubleshooting Commands
+
+### Log Inspection
+```bash
+# View recent close-app logs
+tail -f logs/close-apps.log
+tail -20 logs/close-apps.log
+
+# View recent open-app logs
+tail -f logs/open-apps.log
+tail -20 logs/open-apps.log
+
+# View error logs
+tail -f logs/close-apps.err
+tail -f logs/open-apps.err
+```
+
+### Configuration Validation
+```bash
+# Check config file syntax
+cat config/close-apps.conf
+cat config/open-apps.conf
+
+# Check app lists
+cat config/apps-to-close.txt
+cat config/apps-to-open.txt
+```
+
+### Permission Checks
+```bash
+# Check script executability
+ls -la bin/mac-app-lifecycle
+ls -la scripts/**/*.sh
+
+# Check Accessibility permissions (manual)
+# System Settings → Privacy & Security → Accessibility
+
+# Check Automation permissions (manual)
+# System Settings → Privacy & Security → Automation
+```
+
+## Command Categories
+
+### User Operations (Most Common)
+- `./bin/mac-app-lifecycle close --now`
+- `./bin/mac-app-lifecycle open --now`
+- `./bin/mac-app-lifecycle status`
+- `./bin/mac-app-lifecycle logs close`
+
+### Administrative
+- `./install.sh`
+- `./uninstall.sh`
+- `./bin/mac-app-lifecycle plist close`
+
+### Development
+- `npm run test:all`
+- `npm run test:cli`
+- `./scripts/close-apps/close-apps.sh`
+
+### System-Level
+- `launchctl list com.user.mac-app-lifecycle.close`
+- `ls -la ~/Library/LaunchAgents/`
+
+## Common Workflows
+
+### First-Time Setup
+```bash
+./install.sh
+./bin/mac-app-lifecycle status
+./bin/mac-app-lifecycle close --now
+```
+
+### Daily Usage
+```bash
+./bin/mac-app-lifecycle status
+./bin/mac-app-lifecycle logs close
+```
+
+### Troubleshooting Issues
+```bash
+./bin/mac-app-lifecycle status
+./bin/mac-app-lifecycle plist close
+tail -20 logs/close-apps.log
+launchctl list com.user.mac-app-lifecycle.close
+```
+
+### Development Testing
+```bash
+npm run test:all
+./bin/mac-app-lifecycle close --dry-run
+DRY_RUN=1 ./scripts/close-apps/close-apps.sh
+```
+
+## Exit Codes
+
+The CLI tool uses these exit codes:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Installation validation failed |
+| 3 | Configuration validation failed |
+| 4 | Command execution failed |
+
+## Notes
+
+- All paths are relative to the repository root
+- CLI commands validate installation before running
+- Use `--dry-run` to preview operations
+- Use `--verbose` for detailed output
+- Scripts automatically create log directories as needed
+- launchd agents are managed by install.sh/uninstall.sh
+
+## See Also
+
+- [Installation Guide](INSTALLATION.md) - Setup instructions
+- [Configuration Reference](CONFIGURATION.md) - Config options
+- [Troubleshooting Guide](TROUBLESHOOTING.md) - Common issues
+- [Migration Plan](MIGRATION_PLAN.md) - Development roadmap
+
+---
+
+**Note**: This document is the comprehensive commands reference. For specific guides, see the documentation links above.</content>
+<parameter name="filePath">/Users/charlesbrownroberts/Code/CGB/mac-app-lifecycle-manager/docs/COMMANDS.md

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,86 +1,197 @@
 # Installation Guide
 
-> **Note:** This is a stub document for Phase 1. Full installation instructions will be added in Phase 5.
+This guide covers installing the macOS App Lifecycle Manager using the automated installation script.
 
 ## Quick Start
 
-The installation process will be automated via `install.sh` script in Phase 5.
-
-## Manual Setup (For Development)
-
-For Phase 1-4 development and testing:
-
-1. **Clone the repository:**
+1. **Download and extract:**
    ```bash
+   # Download the latest release or clone the repository
    git clone <repository-url>
    cd mac-app-lifecycle-manager
    ```
 
-2. **Copy config templates:**
+2. **Run the installer:**
    ```bash
-   cd mac-app-lifecycle-manager
-   cp config/close-apps.conf.example config/close-apps.conf
-   cp config/open-apps.conf.example config/open-apps.conf
+   ./install.sh
    ```
 
-3. **Copy app list templates:**
+3. **Follow the prompts:**
+   - Enter your preferred close and open times
+   - The script will set up everything automatically
+
+4. **Configure permissions** (see below)
+
+5. **Test the installation:**
    ```bash
+   ./bin/mac-app-lifecycle status
+   ./bin/mac-app-lifecycle close --now
+   ```
+
+## Automated Installation
+
+The `install.sh` script handles the complete setup:
+
+### What it does:
+- Prompts for schedule times (close apps, open apps)
+- Copies configuration templates to user files
+- Creates the logs directory
+- Generates launchd plist files from templates
+- Copies plists to `~/Library/LaunchAgents/`
+- Sets executable permissions on scripts
+- Loads the launchd agents
+- Validates the installation
+- Provides permission setup instructions
+
+### Options:
+- `--dry-run`: Show what would be done without making changes
+- `--verbose`: Enable verbose output
+
+### Example:
+```bash
+# Dry run first
+./install.sh --dry-run
+
+# Full installation
+./install.sh
+
+# Verbose installation
+./install.sh --verbose
+```
+
+## System Requirements
+
+- **macOS**: 10.15 (Catalina) or later
+- **Commands**: `osascript`, `launchctl` (included with macOS)
+- **Shell**: Bash 3.2+ or zsh
+
+## Required Permissions
+
+After installation, configure these macOS permissions:
+
+### 1. Accessibility Permissions
+Required for AppleScript to control applications.
+
+1. Open **System Settings** → **Privacy & Security** → **Accessibility**
+2. Click the **+** button
+3. Add your terminal application (Terminal.app, iTerm.app, etc.)
+4. Ensure it's enabled (checkmark)
+
+### 2. Automation Permissions
+Required for controlling other applications.
+
+1. Open **System Settings** → **Privacy & Security** → **Automation**
+2. Find your terminal application in the list
+3. Enable automation for the applications you want to control:
+   - Apps you want to close (from `apps-to-close.txt`)
+   - Apps you want to open (from `apps-to-open.txt`)
+
+### 3. Full Disk Access (if needed)
+May be required for some terminal applications.
+
+1. Open **System Settings** → **Privacy & Security** → **Full Disk Access**
+2. Click the **+** button
+3. Add your terminal application
+
+### Testing Permissions
+After setting permissions, test with:
+```bash
+./bin/mac-app-lifecycle close --now
+```
+
+If you see permission prompts, accept them and try again.
+
+## Manual Setup (Development)
+
+For development or manual installation:
+
+1. **Copy config templates:**
+   ```bash
+   cp config/close-apps.conf.example config/close-apps.conf
+   cp config/open-apps.conf.example config/open-apps.conf
    cp config/apps-to-close.txt.example config/apps-to-close.txt
    cp config/apps-to-open.txt.example config/apps-to-open.txt
    ```
 
-4. **Edit configuration files:**
+2. **Edit configurations:**
    ```bash
-   # Customize schedules, paths, and behavior
+   # Customize schedules and paths
    vim config/close-apps.conf
    vim config/open-apps.conf
-   
-   # Customize app lists
-   vim config/apps-to-close.txt
-   vim config/apps-to-open.txt
    ```
 
-5. **Create log directory:**
+3. **Create logs directory:**
    ```bash
    mkdir -p logs
    ```
 
-## System Requirements
+4. **Generate launchd plists:**
+   ```bash
+   # Use the templates in launchd/ directory
+   # Customize schedule times in the generated plists
+   cp launchd/com.user.mac-app-lifecycle.close.plist.template ~/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist
+   cp launchd/com.user.mac-app-lifecycle.open.plist.template ~/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist
+   ```
 
-- macOS 10.15 (Catalina) or later
-- `osascript` (included with macOS)
-- `launchctl` (included with macOS)
-- Bash 3.2+ or zsh
+5. **Set permissions and load:**
+   ```bash
+   chmod +x bin/mac-app-lifecycle scripts/*/close-apps.sh scripts/*/open-apps.sh
+   launchctl load ~/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist
+   launchctl load ~/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist
+   ```
 
-## Required Permissions
+## Uninstallation
 
-macOS will prompt for these permissions the first time you run the scripts:
+To remove the macOS App Lifecycle Manager:
 
-- **Accessibility** - Required for AppleScript to control apps
-- **Automation** - Per-app approval for controlling other apps
-- **Full Disk Access** - May be needed for Terminal.app or script runner
+```bash
+./uninstall.sh
+```
 
-Configure in: System Settings → Privacy & Security → Accessibility / Automation
+The uninstaller will:
+- Unload launchd agents
+- Remove plist files
+- Optionally remove config files and logs (with confirmation)
 
-## What's Coming in Phase 5
+Note: macOS permissions are not automatically removed - disable them manually in System Settings.
 
-The full installation script (`install.sh`) will:
-- ✅ Interactive setup with prompts for schedules
-- ✅ Automatic config file generation
-- ✅ launchd plist generation from templates
-- ✅ Permission verification
-- ✅ Installation validation
-- ✅ Automatic loading of launchd agents
+## Verification
+
+After installation, verify everything works:
+
+```bash
+# Check agent status
+./bin/mac-app-lifecycle status
+
+# Test manual operations
+./bin/mac-app-lifecycle close --now
+./bin/mac-app-lifecycle open --now
+
+# Check logs
+./bin/mac-app-lifecycle logs close
+./bin/mac-app-lifecycle logs open
+```
+
+## Troubleshooting
+
+If installation fails:
+- Check the error messages from `install.sh`
+- Ensure you're running on macOS 10.15+
+- Verify you have write access to `~/Library/LaunchAgents/`
+- See [Troubleshooting Guide](TROUBLESHOOTING.md) for common issues
+
+## Configuration
+
+After installation, customize behavior by editing:
+- `config/close-apps.conf` - Close apps configuration
+- `config/open-apps.conf` - Open apps configuration
+- `config/apps-to-close.txt` - List of apps to close
+- `config/apps-to-open.txt` - List of apps to open
+
+See [Configuration Reference](CONFIGURATION.md) for details.
 
 ## Documentation
 
 - [Configuration Reference](CONFIGURATION.md) - All config options
 - [Troubleshooting Guide](TROUBLESHOOTING.md) - Common issues
 - [Migration Plan](MIGRATION_PLAN.md) - Development roadmap
-
-## Support
-
-For issues during development, see:
-- Phase 1 implementation details in `docs/MIGRATION_PLAN.md`
-- Configuration examples in `config/README.md`
-- Original implementation in `original-scripts-to-be-migrated/`

--- a/docs/PHASE_5_PLAN.md
+++ b/docs/PHASE_5_PLAN.md
@@ -1,0 +1,58 @@
+# Phase 5: Installation & Uninstall Scripts
+
+## Overview
+Automate setup and cleanup for the macOS App Lifecycle Manager.
+
+## Goal
+Create automated installation and uninstallation scripts that handle the complete setup and teardown of the system, including configuration, launchd agents, and documentation updates.
+
+## Deliverables
+
+### 1. Create `install.sh`
+- **Interactive prompts for schedule times**: Ask user for close and open schedule times (HH:MM format)
+- **Copy `.example` templates**: Create user config files from templates in `config/` (close-apps.conf, open-apps.conf, apps-to-close.txt, apps-to-open.txt)
+- **Create log directory**: Ensure `logs/` exists
+- **Generate plist files**: Use templates in `launchd/` to create personalized plist files with user's schedule
+- **Copy plists to LaunchAgents**: Install to `~/Library/LaunchAgents/`
+- **Set executable permissions**: On scripts and the CLI tool
+- **Load launchd agents**: Use `launchctl load` to activate the agents
+- **Validate installation**: Check that all files exist, agents are loaded, permissions are set
+- **Instructions for permissions**: Display steps for Accessibility and Automation permissions
+
+### 2. Create `uninstall.sh`
+- **Unload launchd agents**: Use `launchctl unload` to deactivate
+- **Remove plists**: Delete from `~/Library/LaunchAgents/`
+- **Optionally remove config files**: Ask user if they want to remove `.conf` and `.txt` files from `config/`
+- **Optionally remove logs**: Ask user if they want to remove log files from `logs/`
+- **Confirmation prompts**: Especially for destructive actions (configs/logs)
+
+### 3. Update Documentation
+- **docs/INSTALLATION.md**: Step-by-step installation guide using the install.sh script
+- **docs/TROUBLESHOOTING.md**: Common issues, permission setup, error scenarios
+
+## Key Features
+- **Non-destructive**: Backup existing configs if present
+- **Validation**: Check macOS version (10.15+), required commands (osascript, launchctl)
+- **Clear messages**: Success/error feedback with colored output
+- **Idempotent**: Safe to run multiple times without issues
+
+## Dependencies
+- Builds on Phases 1-4: Config templates, launchd templates, scripts, CLI tool
+- Requires: bash/zsh, standard macOS tools
+
+## Testing
+- Test on clean system: Fresh install, verify agents load, schedules work
+- Test uninstall: Removes everything, optional cleanup works
+- Edge cases: Existing configs, permission issues, invalid inputs
+
+## Success Criteria
+- Fresh installation succeeds without errors
+- Uninstall removes all components cleanly
+- Documentation accurately reflects the process
+- Scripts handle edge cases gracefully
+
+## Implementation Notes
+- Use absolute paths where possible
+- Validate user inputs (time formats, paths)
+- Provide clear error messages with troubleshooting steps
+- Make scripts executable and include shebang

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,38 +1,170 @@
 # Troubleshooting Guide
 
-> **Note:** This is a stub document for Phase 1. Common issues and solutions will be added as they are discovered during migration (Phases 2-6).
+This guide helps resolve common issues with the macOS App Lifecycle Manager.
 
-## Known Issues
+## Installation Issues
 
-Issues will be documented here as they are encountered during the migration process.
+### Installation Script Fails
 
-## Common Problems (Placeholder)
+**Symptoms:** `install.sh` exits with error
 
-### Configuration Issues
-*To be documented in Phase 2-3*
+**Common causes:**
+- Not running on macOS
+- macOS version too old (< 10.15)
+- Missing required commands (`osascript`, `launchctl`)
+- No write permission to `~/Library/LaunchAgents/`
 
-### Permission Errors
-*To be documented during testing*
+**Solutions:**
+```bash
+# Check macOS version
+sw_vers -productVersion
 
-### Schedule Not Triggering
-*To be documented in Phase 5*
+# Check required commands
+which osascript launchctl
+
+# Check permissions
+ls -la ~/Library/LaunchAgents/
+```
+
+### launchd Agent Won't Load
+
+**Symptoms:** `launchctl load` fails
+
+**Causes:**
+- Invalid plist syntax
+- Missing script files
+- Permission issues
+
+**Solutions:**
+```bash
+# Validate plist syntax
+plutil ~/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist
+
+# Check script exists and is executable
+ls -la scripts/close-apps/close-apps.sh
+
+# Try manual load with verbose output
+launchctl load -w ~/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist
+```
+
+### Permission Prompts During Installation
+
+**Symptoms:** macOS asks for permissions during setup
+
+**Solution:** Accept the prompts - they're required for the tool to work.
+
+## Runtime Issues
 
 ### Apps Not Closing/Opening
-*To be documented in Phase 2-3*
+
+**Symptoms:** Scripts run but apps don't respond
+
+**Common causes:**
+- Missing Accessibility permissions
+- Missing Automation permissions for specific apps
+- Apps already closed/opened
+- Invalid app names/paths in config
+
+**Solutions:**
+1. **Check Accessibility permissions:**
+   - System Settings → Privacy & Security → Accessibility
+   - Ensure Terminal.app (or your terminal) is enabled
+
+2. **Check Automation permissions:**
+   - System Settings → Privacy & Security → Automation
+   - Enable Terminal.app for each app you want to control
+
+3. **Verify app lists:**
+   ```bash
+   cat config/apps-to-close.txt
+   cat config/apps-to-open.txt
+   ```
+
+4. **Test manually:**
+   ```bash
+   ./bin/mac-app-lifecycle close --now
+   ```
+
+### Schedule Not Triggering
+
+**Symptoms:** Agents loaded but don't run at scheduled times
+
+**Causes:**
+- Incorrect time format in plist
+- System sleep/preferences
+- launchd disabled
+
+**Solutions:**
+```bash
+# Check agent status
+launchctl list com.user.mac-app-lifecycle.close
+
+# Check system time
+date
+
+# Check plist schedule
+grep -A 5 StartCalendarInterval ~/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist
+
+# Test manual trigger
+launchctl start com.user.mac-app-lifecycle.close
+```
+
+### Scripts Exit with Errors
+
+**Symptoms:** Non-zero exit codes, error logs
+
+**Check logs:**
+```bash
+tail -f logs/close-apps.err
+tail -f logs/open-apps.err
+```
+
+**Common errors:**
+- Missing config files
+- Invalid paths
+- Permission denied on log files
+
+## Configuration Issues
+
+### Config File Not Found
+
+**Symptoms:** Script complains about missing config
+
+**Solution:** Ensure config files exist:
+```bash
+ls -la config/
+# If missing, copy from examples
+cp config/close-apps.conf.example config/close-apps.conf
+```
+
+### Invalid Time Format
+
+**Symptoms:** Schedule validation fails
+
+**Solution:** Use 24-hour format HH:MM (e.g., 19:00, 08:30)
+
+### App Paths Incorrect
+
+**Symptoms:** Apps not found
+
+**Solutions:**
+- Use full paths: `/Applications/AppName.app`
+- Check case sensitivity
+- Verify apps exist: `ls "/Applications/AppName.app"`
 
 ## Debugging
 
 ### Enable Debug Logging
 
-Edit your config file:
+Edit config files to increase verbosity:
 ```bash
-# In ~/.config/mac-app-lifecycle/close-apps.conf or open-apps.conf
+# In config/close-apps.conf or config/open-apps.conf
 LOG_LEVEL="DEBUG"
 ```
 
 ### Check Logs
 
-View recent logs:
+View recent activity:
 ```bash
 # Close-apps logs
 tail -f logs/close-apps.log
@@ -41,17 +173,25 @@ tail -f logs/close-apps.err
 # Open-apps logs
 tail -f logs/open-apps.log
 tail -f logs/open-apps.err
+
+# Or use the CLI
+./bin/mac-app-lifecycle logs close
+./bin/mac-app-lifecycle logs open
 ```
 
 ### Test Scripts Manually
 
-Run scripts directly (without launchd):
+Run without launchd:
 ```bash
 # Close apps
 ./scripts/close-apps/close-apps.sh
 
 # Open apps
 ./scripts/open-apps/open-apps.sh
+
+# Or use CLI
+./bin/mac-app-lifecycle close --now
+./bin/mac-app-lifecycle open --now
 ```
 
 ### Check launchd Status
@@ -62,9 +202,8 @@ launchctl list | grep mac-app-lifecycle
 
 # Check specific agent
 launchctl list com.user.mac-app-lifecycle.close
-launchctl list com.user.mac-app-lifecycle.open
 
-# View agent status (macOS 11+)
+# View detailed status (macOS 11+)
 launchctl print gui/$(id -u)/com.user.mac-app-lifecycle.close
 ```
 
@@ -76,7 +215,7 @@ Required for AppleScript to control applications.
 
 **Check:** System Settings → Privacy & Security → Accessibility
 
-**Fix:** Add Terminal.app (or your script runner) to the list
+**Fix:** Add Terminal.app (or your script runner) to the list and enable it
 
 ### Automation Permission
 
@@ -84,11 +223,14 @@ Required for each app that will be controlled.
 
 **Check:** System Settings → Privacy & Security → Automation
 
-**Fix:** Approve requests as they appear, or pre-approve Terminal.app
+**Fix:** 
+1. Find your terminal app in the list
+2. Enable automation for each app you want to control
+3. Accept prompts as they appear
 
 ### Full Disk Access
 
-May be required for certain apps or directories.
+May be required for certain terminal applications.
 
 **Check:** System Settings → Privacy & Security → Full Disk Access
 
@@ -103,19 +245,15 @@ May be required for certain apps or directories.
 
 ## Reporting Issues
 
-When reporting issues during development, include:
-- macOS version
+When reporting issues, include:
+- macOS version: `sw_vers -productVersion`
 - Relevant log snippets
-- Config file (sanitize personal paths)
+- Config files (sanitize personal paths)
 - Steps to reproduce
 - Expected vs. actual behavior
 
 ## See Also
 
-- [Configuration Reference](CONFIGURATION.md) - All config options
 - [Installation Guide](INSTALLATION.md) - Setup instructions
+- [Configuration Reference](CONFIGURATION.md) - All config options
 - [Migration Plan](MIGRATION_PLAN.md) - Development roadmap
-
----
-
-**This document will be expanded during Phases 2-6 as issues are discovered and resolved.**

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,336 @@
+#!/bin/bash
+
+# macOS App Lifecycle Manager - Installation Script
+# Version: 0.0.14
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Script variables
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRY_RUN=false
+VERBOSE=false
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}INFO:${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}SUCCESS:${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}WARNING:${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}ERROR:${NC} $1" >&2
+}
+
+# Validate time format (HH:MM)
+validate_time() {
+    local time="$1"
+    if [[ ! "$time" =~ ^([01]?[0-9]|2[0-3]):[0-5][0-9]$ ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# Prompt for time with validation
+prompt_time() {
+    local prompt="$1"
+    local default="$2"
+    local time
+
+    while true; do
+        read -p "$prompt [$default]: " time
+        time="${time:-$default}"
+
+        if validate_time "$time"; then
+            echo "$time"
+            return 0
+        else
+            log_error "Invalid time format. Please use HH:MM (24-hour format)."
+        fi
+    done
+}
+
+# Check if file exists and prompt to edit
+handle_existing_file() {
+    local file="$1"
+    local description="$2"
+
+    if [[ -f "$file" ]]; then
+        log_warning "$description already exists at $file"
+        read -p "Do you want to edit it now? (y/n) [n]: " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            ${EDITOR:-nano} "$file"
+        fi
+        return 1
+    fi
+    return 0
+}
+
+# Copy example to config file
+copy_config() {
+    local example="$1"
+    local config="$2"
+    local description="$3"
+
+    if handle_existing_file "$config" "$description"; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log_info "[DRY RUN] Would copy $example to $config"
+        else
+            cp "$example" "$config"
+            log_success "Created $description"
+        fi
+    fi
+}
+
+# Generate plist from template
+generate_plist() {
+    local template="$1"
+    local output="$2"
+    local time="$3"
+    local log_path="$4"
+    local err_log_path="$5"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY RUN] Would generate plist $output from $template"
+        return
+    fi
+
+    # Split time into hour and minute
+    IFS=':' read -r schedule_hour schedule_minute <<< "$time"
+
+    # Use sed to replace placeholders
+    sed \
+        -e "s|{{REPO_ROOT}}|$REPO_ROOT|g" \
+        -e "s|{{SCHEDULE_HOUR}}|$schedule_hour|g" \
+        -e "s|{{SCHEDULE_MINUTE}}|$schedule_minute|g" \
+        -e "s|{{LOG_PATH}}|$log_path|g" \
+        -e "s|{{ERR_LOG_PATH}}|$err_log_path|g" \
+        -e "s|{{WEEKDAYS_ENTRY}}||g" \
+        "$template" > "$output"
+
+    log_success "Generated plist: $output"
+}
+
+# Set executable permissions
+set_permissions() {
+    local files=("$@")
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY RUN] Would set executable permissions on: ${files[*]}"
+        return
+    fi
+
+    chmod +x "${files[@]}"
+    log_success "Set executable permissions"
+}
+
+# Load launchd agent
+load_agent() {
+    local plist="$1"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY RUN] Would load launchd agent: $plist"
+        return
+    fi
+
+    if launchctl load "$plist"; then
+        log_success "Loaded launchd agent: $(basename "$plist")"
+    else
+        log_error "Failed to load launchd agent: $(basename "$plist")"
+        return 1
+    fi
+}
+
+# Validate installation
+validate_installation() {
+    local issues=0
+
+    # Check config files
+    for config in "close-apps.conf" "open-apps.conf" "apps-to-close.txt" "apps-to-open.txt"; do
+        if [[ ! -f "config/$config" ]]; then
+            log_error "Missing config file: config/$config"
+            ((issues++))
+        fi
+    done
+
+    # Check logs directory
+    if [[ ! -d "logs" ]]; then
+        log_error "Missing logs directory"
+        ((issues++))
+    fi
+
+    # Check plist files
+    for plist in "com.user.mac-app-lifecycle.close.plist" "com.user.mac-app-lifecycle.open.plist"; do
+        if [[ ! -f "$HOME/Library/LaunchAgents/$plist" ]]; then
+            log_error "Missing launchd plist: $HOME/Library/LaunchAgents/$plist"
+            ((issues++))
+        fi
+    done
+
+    # Check agent status
+    for label in "com.user.mac-app-lifecycle.close" "com.user.mac-app-lifecycle.open"; do
+        if ! launchctl list | grep -q "$label"; then
+            log_error "Launchd agent not loaded: $label"
+            ((issues++))
+        fi
+    done
+
+    # Check permissions
+    for script in "bin/mac-app-lifecycle" "scripts/close-apps/close-apps.sh" "scripts/open-apps/open-apps.sh"; do
+        if [[ ! -x "$script" ]]; then
+            log_error "Missing executable permission: $script"
+            ((issues++))
+        fi
+    done
+
+    if [[ $issues -eq 0 ]]; then
+        log_success "Installation validation passed"
+        return 0
+    else
+        log_error "Installation validation failed with $issues issues"
+        return 1
+    fi
+}
+
+# Print permission instructions
+print_permission_instructions() {
+    echo
+    log_info "IMPORTANT: macOS Permissions Setup"
+    echo
+    echo "This tool requires macOS permissions to control applications:"
+    echo
+    echo "1. Accessibility Permissions:"
+    echo "   - Open System Settings → Privacy & Security → Accessibility"
+    echo "   - Add and enable Terminal.app (or your terminal)"
+    echo
+    echo "2. Automation Permissions:"
+    echo "   - Open System Settings → Privacy & Security → Automation"
+    echo "   - Find your terminal app in the list"
+    echo "   - Enable automation for the apps you want to control"
+    echo
+    echo "3. Full Disk Access (if needed):"
+    echo "   - Open System Settings → Privacy & Security → Full Disk Access"
+    echo "   - Add Terminal.app"
+    echo
+    echo "After setting permissions, restart your terminal and test with:"
+    echo "  ./bin/mac-app-lifecycle close --now"
+    echo
+}
+
+# Main installation function
+main() {
+    echo "macOS App Lifecycle Manager - Installation"
+    echo "========================================"
+    echo
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run)
+                DRY_RUN=true
+                log_warning "DRY RUN MODE - No changes will be made"
+                ;;
+            --verbose)
+                VERBOSE=true
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                echo "Usage: $0 [--dry-run] [--verbose]"
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    # Validate environment
+    if [[ "$(uname)" != "Darwin" ]]; then
+        log_error "This script is for macOS only"
+        exit 1
+    fi
+
+    # Check macOS version (10.15+)
+    if ! sw_vers -productVersion | awk -F. '{ if ($1 < 10 || ($1 == 10 && $2 < 15)) exit 1 }'; then
+        log_error "macOS 10.15 (Catalina) or later required"
+        exit 1
+    fi
+
+    # Check required commands
+    for cmd in osascript launchctl; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            log_error "Required command not found: $cmd"
+            exit 1
+        fi
+    done
+
+    # Prompt for schedule times
+    echo "Configure schedules (24-hour format):"
+    CLOSE_TIME=$(prompt_time "Close apps time" "19:00")
+    OPEN_TIME=$(prompt_time "Open apps time" "08:00")
+    echo
+
+    # Copy config files
+    log_info "Setting up configuration files..."
+    copy_config "config/close-apps.conf.example" "config/close-apps.conf" "close-apps configuration"
+    copy_config "config/open-apps.conf.example" "config/open-apps.conf" "open-apps configuration"
+    copy_config "config/apps-to-close.txt.example" "config/apps-to-close.txt" "apps-to-close list"
+    copy_config "config/apps-to-open.txt.example" "config/apps-to-open.txt" "apps-to-open list"
+
+    # Create logs directory
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY RUN] Would create logs directory"
+    else
+        mkdir -p logs
+        log_success "Created logs directory"
+    fi
+
+    # Generate plist files
+    log_info "Generating launchd plist files..."
+    generate_plist "launchd/com.user.mac-app-lifecycle.close.plist.template" \
+                   "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist" \
+                   "$CLOSE_TIME" \
+                   "$REPO_ROOT/logs/close-apps.log" \
+                   "$REPO_ROOT/logs/close-apps.err"
+
+    generate_plist "launchd/com.user.mac-app-lifecycle.open.plist.template" \
+                   "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist" \
+                   "$OPEN_TIME" \
+                   "$REPO_ROOT/logs/open-apps.log" \
+                   "$REPO_ROOT/logs/open-apps.err"
+
+    # Set permissions
+    log_info "Setting executable permissions..."
+    set_permissions "bin/mac-app-lifecycle" \
+                    "scripts/close-apps/close-apps.sh" \
+                    "scripts/open-apps/open-apps.sh"
+
+    # Load launchd agents
+    log_info "Loading launchd agents..."
+    load_agent "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist"
+    load_agent "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist"
+
+    # Validate installation
+    log_info "Validating installation..."
+    if validate_installation; then
+        log_success "Installation completed successfully!"
+        print_permission_instructions
+    else
+        log_error "Installation completed with issues. Please check the errors above."
+        exit 1
+    fi
+}
+
+# Run main function
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -5,34 +5,14 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+# Source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/scripts/lib/common.sh"
 
 # Script variables
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
 DRY_RUN=false
 VERBOSE=false
-
-# Logging functions
-log_info() {
-    echo -e "${BLUE}INFO:${NC} $1"
-}
-
-log_success() {
-    echo -e "${GREEN}SUCCESS:${NC} $1"
-}
-
-log_warning() {
-    echo -e "${YELLOW}WARNING:${NC} $1"
-}
-
-log_error() {
-    echo -e "${RED}ERROR:${NC} $1" >&2
-}
 
 # Validate time format (HH:MM)
 validate_time() {
@@ -57,7 +37,7 @@ prompt_time() {
             echo "$time"
             return 0
         else
-            log_error "Invalid time format. Please use HH:MM (24-hour format)."
+            user_log_error "Invalid time format. Please use HH:MM (24-hour format)."
         fi
     done
 }
@@ -68,7 +48,7 @@ handle_existing_file() {
     local description="$2"
 
     if [[ -f "$file" ]]; then
-        log_warning "$description already exists at $file"
+        user_log_warning "$description already exists at $file"
         read -p "Do you want to edit it now? (y/n) [n]: " -n 1 -r
         echo
         if [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -87,10 +67,10 @@ copy_config() {
 
     if handle_existing_file "$config" "$description"; then
         if [[ "$DRY_RUN" == "true" ]]; then
-            log_info "[DRY RUN] Would copy $example to $config"
+            user_log_info "[DRY RUN] Would copy $example to $config"
         else
             cp "$example" "$config"
-            log_success "Created $description"
+            user_log_success "Created $description"
         fi
     fi
 }
@@ -104,7 +84,7 @@ generate_plist() {
     local err_log_path="$5"
 
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[DRY RUN] Would generate plist $output from $template"
+        user_log_info "[DRY RUN] Would generate plist $output from $template"
         return
     fi
 
@@ -121,7 +101,7 @@ generate_plist() {
         -e "s|{{WEEKDAYS_ENTRY}}||g" \
         "$template" > "$output"
 
-    log_success "Generated plist: $output"
+    user_log_success "Generated plist: $output"
 }
 
 # Set executable permissions
@@ -129,12 +109,12 @@ set_permissions() {
     local files=("$@")
 
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[DRY RUN] Would set executable permissions on: ${files[*]}"
+        user_log_info "[DRY RUN] Would set executable permissions on: ${files[*]}"
         return
     fi
 
     chmod +x "${files[@]}"
-    log_success "Set executable permissions"
+    user_log_success "Set executable permissions"
 }
 
 # Load launchd agent
@@ -142,14 +122,14 @@ load_agent() {
     local plist="$1"
 
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[DRY RUN] Would load launchd agent: $plist"
+        user_log_info "[DRY RUN] Would load launchd agent: $plist"
         return
     fi
 
     if launchctl load "$plist"; then
-        log_success "Loaded launchd agent: $(basename "$plist")"
+        user_log_success "Loaded launchd agent: $(basename "$plist")"
     else
-        log_error "Failed to load launchd agent: $(basename "$plist")"
+        user_log_error "Failed to load launchd agent: $(basename "$plist")"
         return 1
     fi
 }
@@ -161,21 +141,21 @@ validate_installation() {
     # Check config files
     for config in "close-apps.conf" "open-apps.conf" "apps-to-close.txt" "apps-to-open.txt"; do
         if [[ ! -f "config/$config" ]]; then
-            log_error "Missing config file: config/$config"
+            user_log_error "Missing config file: config/$config"
             ((issues++))
         fi
     done
 
     # Check logs directory
     if [[ ! -d "logs" ]]; then
-        log_error "Missing logs directory"
+        user_log_error "Missing logs directory"
         ((issues++))
     fi
 
     # Check plist files
     for plist in "com.user.mac-app-lifecycle.close.plist" "com.user.mac-app-lifecycle.open.plist"; do
         if [[ ! -f "$HOME/Library/LaunchAgents/$plist" ]]; then
-            log_error "Missing launchd plist: $HOME/Library/LaunchAgents/$plist"
+            user_log_error "Missing launchd plist: $HOME/Library/LaunchAgents/$plist"
             ((issues++))
         fi
     done
@@ -183,7 +163,7 @@ validate_installation() {
     # Check agent status
     for label in "com.user.mac-app-lifecycle.close" "com.user.mac-app-lifecycle.open"; do
         if ! launchctl list | grep -q "$label"; then
-            log_error "Launchd agent not loaded: $label"
+            user_log_error "Launchd agent not loaded: $label"
             ((issues++))
         fi
     done
@@ -191,16 +171,16 @@ validate_installation() {
     # Check permissions
     for script in "bin/mac-app-lifecycle" "scripts/close-apps/close-apps.sh" "scripts/open-apps/open-apps.sh"; do
         if [[ ! -x "$script" ]]; then
-            log_error "Missing executable permission: $script"
+            user_log_error "Missing executable permission: $script"
             ((issues++))
         fi
     done
 
     if [[ $issues -eq 0 ]]; then
-        log_success "Installation validation passed"
+        user_log_success "Installation validation passed"
         return 0
     else
-        log_error "Installation validation failed with $issues issues"
+        user_log_error "Installation validation failed with $issues issues"
         return 1
     fi
 }
@@ -208,7 +188,7 @@ validate_installation() {
 # Print permission instructions
 print_permission_instructions() {
     echo
-    log_info "IMPORTANT: macOS Permissions Setup"
+    user_log_info "IMPORTANT: macOS Permissions Setup"
     echo
     echo "This tool requires macOS permissions to control applications:"
     echo
@@ -241,13 +221,13 @@ main() {
         case $1 in
             --dry-run)
                 DRY_RUN=true
-                log_warning "DRY RUN MODE - No changes will be made"
+                user_log_warning "DRY RUN MODE - No changes will be made"
                 ;;
             --verbose)
                 VERBOSE=true
                 ;;
             *)
-                log_error "Unknown option: $1"
+                user_log_error "Unknown option: $1"
                 echo "Usage: $0 [--dry-run] [--verbose]"
                 exit 1
                 ;;
@@ -257,20 +237,20 @@ main() {
 
     # Validate environment
     if [[ "$(uname)" != "Darwin" ]]; then
-        log_error "This script is for macOS only"
+        user_log_error "This script is for macOS only"
         exit 1
     fi
 
     # Check macOS version (10.15+)
     if ! sw_vers -productVersion | awk -F. '{ if ($1 < 10 || ($1 == 10 && $2 < 15)) exit 1 }'; then
-        log_error "macOS 10.15 (Catalina) or later required"
+        user_log_error "macOS 10.15 (Catalina) or later required"
         exit 1
     fi
 
     # Check required commands
     for cmd in osascript launchctl; do
         if ! command -v "$cmd" >/dev/null 2>&1; then
-            log_error "Required command not found: $cmd"
+            user_log_error "Required command not found: $cmd"
             exit 1
         fi
     done
@@ -282,7 +262,7 @@ main() {
     echo
 
     # Copy config files
-    log_info "Setting up configuration files..."
+    user_log_info "Setting up configuration files..."
     copy_config "config/close-apps.conf.example" "config/close-apps.conf" "close-apps configuration"
     copy_config "config/open-apps.conf.example" "config/open-apps.conf" "open-apps configuration"
     copy_config "config/apps-to-close.txt.example" "config/apps-to-close.txt" "apps-to-close list"
@@ -290,14 +270,14 @@ main() {
 
     # Create logs directory
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[DRY RUN] Would create logs directory"
+        user_log_info "[DRY RUN] Would create logs directory"
     else
         mkdir -p logs
-        log_success "Created logs directory"
+        user_log_success "Created logs directory"
     fi
 
     # Generate plist files
-    log_info "Generating launchd plist files..."
+    user_log_info "Generating launchd plist files..."
     generate_plist "launchd/com.user.mac-app-lifecycle.close.plist.template" \
                    "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist" \
                    "$CLOSE_TIME" \
@@ -311,23 +291,23 @@ main() {
                    "$REPO_ROOT/logs/open-apps.err"
 
     # Set permissions
-    log_info "Setting executable permissions..."
+    user_log_info "Setting executable permissions..."
     set_permissions "bin/mac-app-lifecycle" \
                     "scripts/close-apps/close-apps.sh" \
                     "scripts/open-apps/open-apps.sh"
 
     # Load launchd agents
-    log_info "Loading launchd agents..."
+    user_log_info "Loading launchd agents..."
     load_agent "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist"
     load_agent "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist"
 
     # Validate installation
-    log_info "Validating installation..."
+    user_log_info "Validating installation..."
     if validate_installation; then
-        log_success "Installation completed successfully!"
+        user_log_success "Installation completed successfully!"
         print_permission_instructions
     else
-        log_error "Installation completed with issues. Please check the errors above."
+        user_log_error "Installation completed with issues. Please check the errors above."
         exit 1
     fi
 }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -53,6 +53,61 @@ log_message() {
 }
 
 # =============================================================================
+# COLOR SUPPORT
+# =============================================================================
+
+# Color codes (only if terminal supports colors)
+if [[ -t 1 ]] && [[ -n "${TERM:-}" ]] && [[ "$TERM" != "dumb" ]]; then
+    # Terminal supports colors
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    PURPLE='\033[0;35m'
+    CYAN='\033[0;36m'
+    WHITE='\033[1;37m'
+    NC='\033[0m' # No Color
+else
+    # No color support
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    PURPLE=''
+    CYAN=''
+    WHITE=''
+    NC=''
+fi
+
+# =============================================================================
+# USER-FRIENDLY LOGGING (for install/uninstall scripts)
+# =============================================================================
+
+# User-friendly logging functions with colors (no timestamps for cleaner output)
+# Usage: user_log_info "Message text"
+user_log_info() {
+  echo -e "${BLUE}INFO:${NC} $1"
+}
+
+# Log a success message
+# Usage: user_log_success "Success message"
+user_log_success() {
+  echo -e "${GREEN}SUCCESS:${NC} $1"
+}
+
+# Log a warning message
+# Usage: user_log_warning "Warning message"
+user_log_warning() {
+  echo -e "${YELLOW}WARNING:${NC} $1"
+}
+
+# Log an error message
+# Usage: user_log_error "Error message"
+user_log_error() {
+  echo -e "${RED}ERROR:${NC} $1" >&2
+}
+
+# =============================================================================
 # VALIDATION FUNCTIONS
 # =============================================================================
 

--- a/tests/test-cli-commands.sh
+++ b/tests/test-cli-commands.sh
@@ -240,6 +240,55 @@ test_logs_command_stub() {
   fi
 }
 
+test_plist_command_stub() {
+  test_start "Plist command functionality"
+
+  # Test plist command without subcommand (should show error)
+  local output
+  local exit_code
+  output=$("$CLI_SCRIPT" plist 2>&1) || exit_code=$?
+
+  if [[ ${exit_code:-0} -eq 1 ]]; then
+    test_pass "Plist command without subcommand returns exit code 1"
+  else
+    test_fail "Plist command without subcommand should return exit code 1, got ${exit_code:-0}"
+    return 1
+  fi
+
+  if echo "$output" | grep -q "Please specify 'close' or 'open' plist"; then
+    test_pass "Plist command shows appropriate error message for missing subcommand"
+  else
+    test_fail "Plist command does not show appropriate error message for missing subcommand"
+    return 1
+  fi
+
+  # Test plist close command
+  if output=$("$CLI_SCRIPT" plist close 2>&1); then
+    if echo "$output" | grep -q "Close Apps Plist Configuration"; then
+      test_pass "Plist close command shows header"
+    else
+      test_fail "Plist close command does not show expected header"
+      return 1
+    fi
+  else
+    test_fail "Plist close command failed to execute"
+    return 1
+  fi
+
+  # Test plist open command
+  if output=$("$CLI_SCRIPT" plist open 2>&1); then
+    if echo "$output" | grep -q "Open Apps Plist Configuration"; then
+      test_pass "Plist open command shows header"
+    else
+      test_fail "Plist open command does not show expected header"
+      return 1
+    fi
+  else
+    test_fail "Plist open command failed to execute"
+    return 1
+  fi
+}
+
 # =============================================================================
 # MAIN
 # =============================================================================
@@ -256,6 +305,7 @@ main() {
   test_no_command
   test_status_command_stub
   test_logs_command_stub
+  test_plist_command_stub
 
   # Summary
   echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,33 +5,13 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+# Source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/scripts/lib/common.sh"
 
 # Script variables
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
 VERBOSE=false
-
-# Logging functions
-log_info() {
-    echo -e "${BLUE}INFO:${NC} $1"
-}
-
-log_success() {
-    echo -e "${GREEN}SUCCESS:${NC} $1"
-}
-
-log_warning() {
-    echo -e "${YELLOW}WARNING:${NC} $1"
-}
-
-log_error() {
-    echo -e "${RED}ERROR:${NC} $1" >&2
-}
 
 # Confirm action
 confirm() {
@@ -50,12 +30,12 @@ unload_agent() {
 
     if launchctl list | grep -q "$label"; then
         if launchctl unload "$plist"; then
-            log_success "Unloaded launchd agent: $label"
+            user_log_success "Unloaded launchd agent: $label"
         else
-            log_warning "Failed to unload launchd agent: $label"
+            user_log_warning "Failed to unload launchd agent: $label"
         fi
     else
-        log_info "Launchd agent not loaded: $label"
+        user_log_info "Launchd agent not loaded: $label"
     fi
 }
 
@@ -66,9 +46,9 @@ remove_file() {
 
     if [[ -f "$file" ]]; then
         rm "$file"
-        log_success "Removed $description: $file"
+        user_log_success "Removed $description: $file"
     else
-        log_info "$description not found: $file"
+        user_log_info "$description not found: $file"
     fi
 }
 
@@ -80,12 +60,12 @@ remove_dir_if_empty() {
     if [[ -d "$dir" ]]; then
         if [[ -z "$(ls -A "$dir" 2>/dev/null)" ]]; then
             rmdir "$dir"
-            log_success "Removed empty $description: $dir"
+            user_log_success "Removed empty $description: $dir"
         else
-            log_info "$description not empty, keeping: $dir"
+            user_log_info "$description not empty, keeping: $dir"
         fi
     else
-        log_info "$description not found: $dir"
+        user_log_info "$description not found: $dir"
     fi
 }
 
@@ -102,7 +82,7 @@ main() {
                 VERBOSE=true
                 ;;
             *)
-                log_error "Unknown option: $1"
+                user_log_error "Unknown option: $1"
                 echo "Usage: $0 [--verbose]"
                 exit 1
                 ;;
@@ -112,17 +92,17 @@ main() {
 
     # Confirm uninstallation
     if ! confirm "This will uninstall macOS App Lifecycle Manager. Continue?"; then
-        log_info "Uninstallation cancelled"
+        user_log_info "Uninstallation cancelled"
         exit 0
     fi
 
     # Unload launchd agents
-    log_info "Unloading launchd agents..."
+    user_log_info "Unloading launchd agents..."
     unload_agent "com.user.mac-app-lifecycle.close" "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist"
     unload_agent "com.user.mac-app-lifecycle.open" "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist"
 
     # Remove plist files
-    log_info "Removing launchd plist files..."
+    user_log_info "Removing launchd plist files..."
     remove_file "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist" "close plist"
     remove_file "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist" "open plist"
 
@@ -138,7 +118,7 @@ main() {
             remove_file "config/apps-to-open.txt" "apps-to-open list"
             remove_dir_if_empty "config" "config directory"
         else
-            log_info "Keeping configuration files"
+            user_log_info "Keeping configuration files"
         fi
     fi
 
@@ -152,14 +132,14 @@ main() {
             remove_file "logs/open-apps.err" "open-apps error log"
             remove_dir_if_empty "logs" "logs directory"
         else
-            log_info "Keeping log files"
+            user_log_info "Keeping log files"
         fi
     fi
 
-    log_success "Uninstallation completed successfully!"
+    user_log_success "Uninstallation completed successfully!"
     echo
-    log_info "Note: macOS permissions (Accessibility, Automation) are not automatically removed."
-    log_info "You can remove them manually in System Settings → Privacy & Security."
+    user_log_info "Note: macOS permissions (Accessibility, Automation) are not automatically removed."
+    user_log_info "You can remove them manually in System Settings → Privacy & Security."
 }
 
 # Run main function

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+# macOS App Lifecycle Manager - Uninstallation Script
+# Version: 0.0.14
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Script variables
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERBOSE=false
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}INFO:${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}SUCCESS:${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}WARNING:${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}ERROR:${NC} $1" >&2
+}
+
+# Confirm action
+confirm() {
+    local prompt="$1"
+    local default="${2:-n}"
+
+    read -p "$prompt (y/n) [$default]: " -n 1 -r
+    echo
+    [[ $REPLY =~ ^[Yy]$ ]] || [[ -z "$REPLY" && "$default" == "y" ]]
+}
+
+# Unload launchd agent
+unload_agent() {
+    local label="$1"
+    local plist="$2"
+
+    if launchctl list | grep -q "$label"; then
+        if launchctl unload "$plist"; then
+            log_success "Unloaded launchd agent: $label"
+        else
+            log_warning "Failed to unload launchd agent: $label"
+        fi
+    else
+        log_info "Launchd agent not loaded: $label"
+    fi
+}
+
+# Remove file if exists
+remove_file() {
+    local file="$1"
+    local description="$2"
+
+    if [[ -f "$file" ]]; then
+        rm "$file"
+        log_success "Removed $description: $file"
+    else
+        log_info "$description not found: $file"
+    fi
+}
+
+# Remove directory if exists and empty
+remove_dir_if_empty() {
+    local dir="$1"
+    local description="$2"
+
+    if [[ -d "$dir" ]]; then
+        if [[ -z "$(ls -A "$dir" 2>/dev/null)" ]]; then
+            rmdir "$dir"
+            log_success "Removed empty $description: $dir"
+        else
+            log_info "$description not empty, keeping: $dir"
+        fi
+    else
+        log_info "$description not found: $dir"
+    fi
+}
+
+# Main uninstallation function
+main() {
+    echo "macOS App Lifecycle Manager - Uninstallation"
+    echo "=========================================="
+    echo
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --verbose)
+                VERBOSE=true
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                echo "Usage: $0 [--verbose]"
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    # Confirm uninstallation
+    if ! confirm "This will uninstall macOS App Lifecycle Manager. Continue?"; then
+        log_info "Uninstallation cancelled"
+        exit 0
+    fi
+
+    # Unload launchd agents
+    log_info "Unloading launchd agents..."
+    unload_agent "com.user.mac-app-lifecycle.close" "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist"
+    unload_agent "com.user.mac-app-lifecycle.open" "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist"
+
+    # Remove plist files
+    log_info "Removing launchd plist files..."
+    remove_file "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.close.plist" "close plist"
+    remove_file "$HOME/Library/LaunchAgents/com.user.mac-app-lifecycle.open.plist" "open plist"
+
+    # Remove LaunchAgents directory if empty
+    remove_dir_if_empty "$HOME/Library/LaunchAgents" "LaunchAgents directory"
+
+    # Handle config files
+    if [[ -f "config/close-apps.conf" || -f "config/open-apps.conf" || -f "config/apps-to-close.txt" || -f "config/apps-to-open.txt" ]]; then
+        if confirm "Remove configuration files (close-apps.conf, open-apps.conf, apps-to-close.txt, apps-to-open.txt)?"; then
+            remove_file "config/close-apps.conf" "close-apps config"
+            remove_file "config/open-apps.conf" "open-apps config"
+            remove_file "config/apps-to-close.txt" "apps-to-close list"
+            remove_file "config/apps-to-open.txt" "apps-to-open list"
+            remove_dir_if_empty "config" "config directory"
+        else
+            log_info "Keeping configuration files"
+        fi
+    fi
+
+    # Handle logs
+    if [[ -d "logs" ]]; then
+        if confirm "Remove log files and logs directory?"; then
+            # Remove log files
+            remove_file "logs/close-apps.log" "close-apps log"
+            remove_file "logs/close-apps.err" "close-apps error log"
+            remove_file "logs/open-apps.log" "open-apps log"
+            remove_file "logs/open-apps.err" "open-apps error log"
+            remove_dir_if_empty "logs" "logs directory"
+        else
+            log_info "Keeping log files"
+        fi
+    fi
+
+    log_success "Uninstallation completed successfully!"
+    echo
+    log_info "Note: macOS permissions (Accessibility, Automation) are not automatically removed."
+    log_info "You can remove them manually in System Settings → Privacy & Security."
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
Introduces automated scripts for installing and uninstalling the macOS App Lifecycle Manager, enhancing the setup and teardown processes. These scripts handle everything from configuration file setup to managing permissions and launch agents. 

- Introduces user-friendly colored logging for clearer script feedback.
- Expands documentation with a comprehensive installation guide and troubleshooting section.
- Refines testing framework with tests for new command functionalities, ensuring stability.

Relates to issue #16